### PR TITLE
BI 4038 add post hooks to icremental and live

### DIFF
--- a/macros/incremental_and_live.sql
+++ b/macros/incremental_and_live.sql
@@ -578,6 +578,9 @@
         -- append output relation
             {%- do sections_arr.append(target_output_relation) -%}
         --
+        -- run post hooks
+            {{ run_hooks(post_hooks, inside_transaction=True) }}
+
     -- return
         {% call noop_statement('main', 'Done') -%} {%- endcall %}
         {% do return ({'relations': sections_arr}) -%}


### PR DESCRIPTION
Added post hooks run once inside transaction at the end of incremental and live materialization. This hooks would run only if they specified in config.

Needed in https://improvado.atlassian.net/browse/BI-4038 to specify table TTL