### PR TITLE
IHT-17616-fix-create_custom-not-dropping-dictionaries

### DIFF
--- a/macros/materializations/create_custom.sql
+++ b/macros/materializations/create_custom.sql
@@ -109,7 +109,7 @@
                 {% endcall %}
 
                 -- We need to drop the backup relation before we can use its name and to avoid name collisions
-                {{ adapter.drop_relation(backup_relation) }}
+                {% do dbt_improvado_utils.mcr_drop_relation_if_exists(backup_relation) %}
                 {{ adapter.rename_relation(existing_relation, backup_relation) }}
                 {{ adapter.rename_relation(intermediate_relation, target_relation) }}
 

--- a/macros/materializations/create_custom.sql
+++ b/macros/materializations/create_custom.sql
@@ -126,7 +126,7 @@
     {% for rel in to_drop %}
         {% set rel_with_type = load_cached_relation(rel) %}
         {% if rel_with_type %}
-            {{ adapter.drop_relation(rel_with_type) }}
+            {% do dbt_improvado_utils.mcr_drop_relation_if_exists(rel_with_type) %}
         {% endif %}
     {% endfor %}
 


### PR DESCRIPTION
fixes errors like this: 
```
   Code: 520. DB::Exception: Cannot drop/detach dictionary internal_analytics_src_atomic.src_dts_agencies__dbt_backup as table, use DROP DICTIONARY or DETACH DICTIONARY query instead. (CANNOT_DETACH_DICTIONARY_AS_TABLE) (version 24.3.5.46 (official build))
```