### PR TITLE
fix(materializations): Fit issue with microbatch 'date to'

### DIFF
--- a/macros/materializations/microbatch.sql
+++ b/macros/materializations/microbatch.sql
@@ -480,7 +480,7 @@
     {%- else -%}
         {%- set left_having_condition = base_date_from -%}
     {%- endif -%}
-    {%- set right_having_condition = base_date_from + diu.get_unit_interval(value=batch_size, unit=time_unit_name) -%}
+    {%- set right_having_condition = interval_start + diu.get_unit_interval(value=batch_size, unit=time_unit_name) -%}
 
     {{- return([lookback_windows_intervals, [left_having_condition, right_having_condition]]) -}}
 {%- endmacro -%}

--- a/macros/materializations/microbatch.sql
+++ b/macros/materializations/microbatch.sql
@@ -475,11 +475,7 @@
     {%- endfor -%}
 
 -- where conditions for final select from from CTE
-    {%- if start_time.date() == interval_start.date() -%}
-        {%- set left_having_condition = interval_start -%}
-    {%- else -%}
-        {%- set left_having_condition = base_date_from -%}
-    {%- endif -%}
+    {%- set left_having_condition = interval_start -%}
     {%- set right_having_condition = interval_start + diu.get_unit_interval(value=batch_size, unit=time_unit_name) -%}
 
     {{- return([lookback_windows_intervals, [left_having_condition, right_having_condition]]) -}}


### PR DESCRIPTION
fix: microbatch date ranges not progressing between batches

Use interval_start consistently for having conditions instead of 
base_date_from to ensure proper time progression across batches

Before:
  Batch 1: from 2025-07-10 10:00:00 to 2025-07-10 18:00:00
  Batch 2: from 2025-07-10 18:00:00 to 2025-07-10 08:00:00  ← backwards!
  Batch 3: from 2025-07-11 00:00:00 to 2025-07-11 08:00:00
  Batch 4: from 2025-07-11 00:00:00 to 2025-07-11 08:00:00  ← duplicate!

After:
  Batch 1: from 2025-07-10 10:00:00 to 2025-07-10 18:00:00
  Batch 2: from 2025-07-10 18:00:00 to 2025-07-11 02:00:00  ✓
  Batch 3: from 2025-07-11 02:00:00 to 2025-07-11 10:00:00  ✓
  Batch 4: from 2025-07-11 10:00:00 to 2025-07-11 18:00:00  ✓