### PR TITLE
BI-9427: guard microbatch ATTACH against duplicated partition copy

### DIFF
--- a/macros/materializations/microbatch.sql
+++ b/macros/materializations/microbatch.sql
@@ -183,6 +183,10 @@
                 'Copying partition "' ~ partition_id ~ '" from ' ~ target_relation ~ ' to ' ~ tmp_relation, silence_mode) -}}
         {%- do diu.copy_partition(target_relation, tmp_relation, partition_id) -%}
 
+    -- guarding against a duplicated ATTACH (e.g. retried statement after a dropped connection)
+    -- must run before any mutation touches tmp, otherwise the duplicate rows are indistinguishable
+        {%- do diu.check_partition_row_count_match(target_relation, tmp_relation, partition_id, silence_mode) -%}
+
     -- deleting data to be overwritten from tmp relation
         {%- do diu.wait_for_merges(tmp_relation) -%}
         {%- do run_query(
@@ -608,6 +612,60 @@
             attach partition id '{{ partition_id }}'
             from {{ existing_relation }}
     {%- endcall -%}
+{%- endmacro -%}
+
+
+{%- macro check_partition_row_count_match(existing_relation, intermediate_relation, partition_id, silence_mode) -%}
+{#
+    Guards against a duplicated ATTACH (e.g. the statement executed twice after a dropped
+    connection and client retry with the same query_id). Compares the row count of the just-copied
+    partition in intermediate_relation against the source partition_id row count in existing_relation
+    right after copy_partition, before any mutation can make the extra copy invisible to
+    check_duplicate_parts' hash-based comparison.
+    Arguments:
+        existing_relation(api.Relation):       The relation the partition was copied from
+        intermediate_relation(api.Relation):   The relation the partition was copied into
+        partition_id(string):                  The partition id that was just copied
+        silence_mode(bool):                    Should the log messages be silenced
+    Returns:
+        None (raises a compiler error on mismatch)
+#}
+    {%- set diu = dbt_improvado_utils -%}
+
+    {%- set row_counts_query -%}
+        select
+            (select sum(rows) from system.parts
+             where database = '{{ existing_relation.schema }}'
+               and table = '{{ existing_relation.identifier }}'
+               and partition_id = '{{ partition_id }}'
+               and active) as target_rows,
+            (select sum(rows) from system.parts
+             where database = '{{ intermediate_relation.schema }}'
+               and table = '{{ intermediate_relation.identifier }}'
+               and partition_id = '{{ partition_id }}'
+               and active) as tmp_rows
+    {%- endset -%}
+
+    {%- if execute -%}
+        {%- set result = run_query(row_counts_query).rows[0] -%}
+        {%- set target_rows = result['target_rows'] or 0 -%}
+        {%- set tmp_rows = result['tmp_rows'] or 0 -%}
+
+        {{- diu.mcr_log_colored(
+                'Row count guard for partition "' ~ partition_id ~ '":\n\ttarget: ' ~ target_rows ~
+                '\n\ttmp: ' ~ tmp_rows, silence_mode) -}}
+
+        {%- if target_rows != tmp_rows -%}
+            {%- do exceptions.raise_compiler_error(
+                    diu.mcr_log_colored(
+                        'ATTACH row-count mismatch on partition "' ~ partition_id ~ '":\n' ~
+                        '\ttarget (' ~ existing_relation ~ '): ' ~ target_rows ~ ' rows\n' ~
+                        '\ttmp (' ~ intermediate_relation ~ '): ' ~ tmp_rows ~ ' rows\n' ~
+                        'This indicates a duplicated ATTACH (e.g. a retried statement after a dropped connection).\n' ~
+                        'Aborting before the delete/insert/REPLACE PARTITION steps would make the duplicate ' ~
+                        'undetectable to check_duplicate_parts.', color='red')) -%}
+        {%- endif -%}
+    {%- endif -%}
 {%- endmacro -%}
 
 {%- macro get_partition_id(datetime_object, partition_by_format) -%}


### PR DESCRIPTION
## Problem

Root-caused via BI-9427 (`fct_product_domain_events` data quality investigation): two incidents (2026-05-20, 2026-06-12) each doubled a full month partition, ~29.2M extra rows total.

Signature in both cases: the microbatch run was interrupted mid-flight (connection drop + client retry with the same query_id / pod death), and a subsequent run published a partition doubled via `REPLACE PARTITION`.

`check_duplicate_parts()` is supposed to catch this, but it compares parts by `hash_of_all_files`. By the time it runs, the tmp relation has already gone through the delete-mutation (removing the overwrite window) and fresh inserts — so the duplicated parts are no longer byte-identical and the check misses them. Same underlying bug pattern as BI-9498 (order_runs, Dec 2025), which is what added `check_duplicate_parts` in the first place — it doesn't cover this scenario.

## Fix

Add `check_partition_row_count_match()`: right after `copy_partition()` (the ATTACH), compare `sum(rows)` in `system.parts` for the just-copied `partition_id` between `target_relation` and `tmp_relation`. They must be equal — nothing has mutated tmp yet at this point. On mismatch, raise a compiler error and abort before the delete/insert/`REPLACE PARTITION` steps, so a duplicated ATTACH never reaches production.

This is generic (no dependency on a model's business key/primary key), so it protects every model using the `microbatch` materialization, not just `fct_product_domain_events`.

## Verification

- Existing pytest suite (`docker exec -i dbt python -m pytest -rA tests/pytest/`) — 3/3 pass. Note these all run with `--full-refresh`, so they exercise `exchange_tables`, not the `copy_partition` path this guard sits on.
- Manual incremental run (no `--full-refresh`) against the `microbatch_test` model — guard logs `target: 356, tmp: 356` and the run completes normally (no false positive).
- Manual reproduction of the actual bug: created a target/tmp table pair mirroring `microbatch_test`'s DDL, ran `ALTER TABLE tmp ATTACH PARTITION ... FROM target` twice. Result: `target = 356 rows`, `tmp = 712 rows` — exact ×2 signature seen in the production incident. Ran the guard's exact `system.parts` query against these tables and confirmed it detects the mismatch (356 ≠ 712).

## Out of scope (tracked separately in BI-9427)

- Cleanup of the existing 202605/202606 duplicate rows in `internal_analytics.fct_product_domain_events` (`OPTIMIZE ... DEDUPLICATE`, dry-run already done).
- Reporting the underlying connection-drop/retry-with-same-query_id behavior (error code 614) to infra.